### PR TITLE
Add the ability to delete zones

### DIFF
--- a/src/components/builder/zone/ZoneDetails.vue
+++ b/src/components/builder/zone/ZoneDetails.vue
@@ -63,7 +63,7 @@
       >Zone has no rooms. Go to an existing room and assign it to this zone to see a map.</div>
       <div>
         <button class="btn-thin edit-mob" @click="editInfo">EDIT</button>
-        <button class="btn-thin color-text-red" @click="deleteZone">DELETE</button>
+        <button class="btn-thin" @click="deleteZone">DELETE</button>
       </div>
     </div>
 

--- a/src/components/builder/zone/ZoneDetails.vue
+++ b/src/components/builder/zone/ZoneDetails.vue
@@ -63,6 +63,7 @@
       >Zone has no rooms. Go to an existing room and assign it to this zone to see a map.</div>
       <div>
         <button class="btn-thin edit-mob" @click="editInfo">EDIT</button>
+        <button class="btn-thin color-text-red" @click="deleteZone">DELETE</button>
       </div>
     </div>
 
@@ -216,16 +217,16 @@ export default class ZoneDetails extends Mixins(ZoneView) {
   }
 
   async deleteZone() {
-    const zone_id = this.$store.state.builder.zone.id;
+    const zone = this.$store.state.builder.zone;
 
     // Crude confirm dialog
-    const c = confirm(`Are you sure you want to delete Zone ${zone_id}?`);
+    const c = confirm(`Are you sure you want to delete Zone ${zone.id}: ${zone.name}?`);
     if (!c) return;
 
     await this.$store.dispatch(BUILDER_ACTIONS.ZONE_DELETE);
     this.$store.commit(
       UI_MUTATIONS.SET_NOTIFICATION,
-      `Deleted Mob Template ${zone_id}`
+      `Deleted Zone ${zone.id}`
     );
   }
 

--- a/src/store/modules/builder.ts
+++ b/src/store/modules/builder.ts
@@ -10,6 +10,7 @@ import { Room } from "@/core/interfaces";
 import router, {
   BUILDER_ZONE_PATH_DETAILS,
   BUILDER_ZONE_INDEX,
+  BUILDER_ZONE_LIST,
   BUILDER_ROOM_INDEX
 } from "@/router";
 import { get_room_index_key } from "@/core/map.ts";
@@ -241,6 +242,12 @@ const actions = {
       `builder/worlds/${state.world.id}/zones/${state.zone.id}/`
     );
     commit("zone_clear");
+    router.push({
+      name: BUILDER_ZONE_LIST,
+      params: {
+        world_id: state.world.id
+      }
+    });
   },
 
   zone_save: async ({ commit, state }, payload) => {
@@ -499,6 +506,10 @@ const mutations = {
 
   zone_set: (state, zone) => {
     state.zone = zone;
+  },
+
+  zone_clear: (state) => {
+    state.zone = null;
   },
 
   zone_rooms_set: (state, zone_rooms) => {


### PR DESCRIPTION
This adds the ability to delete zones that have no rooms assigned to them. Server-side validation will be in another PR to the backend.

See here:
![Screen Shot 2021-09-01 at 1 47 14 PM](https://user-images.githubusercontent.com/341416/131719108-9f9f8b7b-d6d0-41d6-8bba-c11b9c14752d.png)