### PR TITLE
Fixed typo in World Config manage status description

### DIFF
--- a/src/components/builder/world/Config.vue
+++ b/src/components/builder/world/Config.vue
@@ -86,7 +86,7 @@
       <div class="world-status">
         <h3>World Status</h3>
 
-        <div>View connected players, start/stop multilpayer worlds.</div>
+        <div>View connected players, start/stop multiplayer worlds.</div>
 
         <router-link :to="world_status_link">manage</router-link>
       </div>


### PR DESCRIPTION
Fixed minor typo ('multilpayer' -> 'multiplayer') in World Config manage status description.

![image](https://github.com/teebes/herald/assets/746190/35e4c2ef-5896-4560-a6fe-75c5f742b6cb)
